### PR TITLE
Make `Space` key visible on ShortcutPage

### DIFF
--- a/shared/logic/Shortcut.ts
+++ b/shared/logic/Shortcut.ts
@@ -85,7 +85,13 @@ export function getShortcutKey(s: IShortcutConfig): string {
    if (s.meta) {
       keys.push("Command");
    }
-   keys.push(s.key);
+
+   if (s.key == ' ') {
+      keys.push("Space")
+   } else {
+      keys.push(s.key);
+   }
+   
    return keys.join(" + ");
 }
 


### PR DESCRIPTION

![image](https://github.com/fishpondstudio/CivIdle/assets/40712686/e84c7ca8-6984-44a7-ab5a-34efb4415290)

fixes #19 