### PR TITLE
Fix offline time benefit

### DIFF
--- a/src/scripts/Bootstrap.tsx
+++ b/src/scripts/Bootstrap.tsx
@@ -112,7 +112,7 @@ export async function startGame(
          const before = structuredClone(gameState);
          let timeLeft = offlineTime;
          while (timeLeft > 0) {
-            const batchSize = Math.min(offlineTime, MAX_OFFLINE_PRODUCTION_SEC / 100);
+            const batchSize = Math.min(timeLeft, MAX_OFFLINE_PRODUCTION_SEC / 100);
             await schedule(() => {
                for (let i = 0; i < batchSize; i++) {
                   tickEverySecond(gameState, true);


### PR DESCRIPTION
`MAX_OFFLINE_PRODUCTION_SEC / 100` is 144.  If your `offlineTime` is more than 144, say 150, then batchSize will be 144, you'll then get 144 ticks.

Then timeLeft will have 144 taken off it, with 6 left, but the next time round batchSize will be 144 again, because 144 is the min of offlineTime, where it should be timeLeft.