### PR TITLE
Change Upgrade +5 to Next 5

### DIFF
--- a/shared/languages/en.ts
+++ b/shared/languages/en.ts
@@ -769,7 +769,7 @@ export const EN = {
    ShortcutScopePlayerMapPage: "Trade Map Page",
    ShortcutBuildingPageSellBuilding: "Sell Building",
    ShortcutBuildingPageUpgradeX1: "Upgrade x1",
-   ShortcutBuildingPageUpgradeX5: "Upgrade x5",
+   ShortcutBuildingPageUpgradeToNext5: "Upgrade To Next 5",
    ShortcutBuildingPageUpgradeToNext10: "Upgrade To Next 10",
    ShortcutUpgradePageIncreaseLevel: "Increase Upgrade Level",
    ShortcutUpgradePageDecreaseLevel: "Decrease Upgrade Level",

--- a/shared/logic/BuildingLogic.ts
+++ b/shared/logic/BuildingLogic.ts
@@ -511,14 +511,23 @@ export function getBuildingLevelLabel(b: IBuildingData): string {
    return String(b.level);
 }
 
+export function levelToNext5s(b: IBuildingData) {
+   const l = Math.ceil(b.level / 5) * 5 - b.level;
+   return l > 0 ? l : 5;
+}
+
 export function levelToNext10s(b: IBuildingData) {
    const l = Math.ceil(b.level / 10) * 10 - b.level;
    return l > 0 ? l : 10;
 }
 
 export function getBuildingUpgradeLevels(b: IBuildingData): number[] {
+   const next5s = levelToNext5s(b);
    const next10s = levelToNext10s(b);
-   const levels = [1, 5];
+   const levels = [1];
+   if (!levels.includes(next5s)) {
+      levels.push(next5s);
+   }
    if (!levels.includes(next10s)) {
       levels.push(next10s);
    }

--- a/shared/logic/Shortcut.ts
+++ b/shared/logic/Shortcut.ts
@@ -19,7 +19,10 @@ export const ShortcutActions = {
       name: () => t(L.ShortcutBuildingPageSellBuilding),
    },
    BuildingPageUpgradeX1: { scope: "BuildingPage", name: () => t(L.ShortcutBuildingPageUpgradeX1) },
-   BuildingPageUpgradeX5: { scope: "BuildingPage", name: () => t(L.ShortcutBuildingPageUpgradeX5) },
+   BuildingPageUpgradeToNext5: {
+      scope: "BuildingPage",
+      name: () => t(L.ShortcutBuildingPageUpgradeToNext5), 
+   },
    BuildingPageUpgradeToNext10: {
       scope: "BuildingPage",
       name: () => t(L.ShortcutBuildingPageUpgradeToNext10),

--- a/src/scripts/ui/BuildingUpgradeComponent.tsx
+++ b/src/scripts/ui/BuildingUpgradeComponent.tsx
@@ -39,7 +39,7 @@ export function BuildingUpgradeComponent({ gameState, xy }: IBuildingComponentPr
       notifyGameStateUpdate();
    };
    useShortcut("BuildingPageUpgradeX1", () => upgrade(1), [xy]);
-   useShortcut("BuildingPageUpgradeX5", () => upgrade(5), [xy]);
+   useShortcut("BuildingPageUpgradeToNext5", () => upgrade(levels[levels.length - 1]), [xy]);
    useShortcut("BuildingPageUpgradeToNext10", () => upgrade(levels[levels.length - 1]), [xy]);
 
    return (


### PR DESCRIPTION
Zeinath suggested this change here: https://discord.com/channels/631551126377857044/1210661249088618497
It is something I have noticed when playing too

Issue:
Building starts off at level one, if you want to upgrade the building to level 10, its only one click. If you want to upgrade it to level 5, you need to click +5, then -1 in the upgrade menu. 

Solution:
What is being suggested, is to change the "+5" button to function how the "To Next 10" button works, just instead by a multiple of 5.

This is only a small QoL thing and probably not urgent, but it seemed like many people agreed with the suggestion, so I thought it might be a good learning opportunity for myself to try and change it. I am still learning how to code, and this took me 3 hours to figure out haha, but I believe this will work? If it does not work, please let me know where I went wrong, and I will try to fix it :)