### PR TITLE
[QOL] Add navigation between same type buildings

### DIFF
--- a/shared/languages/en.ts
+++ b/shared/languages/en.ts
@@ -977,6 +977,10 @@ export const EN = {
    OpenSaveBackupFolder: "Open Backup Folder",
    ShortcutBuildingPageToggleBuilding: "Toggle Production",
    ShortcutBuildingPageToggleBuildingSetAllSimilar: "Toggle Production And Apply To All",
+   ShortcutShowPrevBuilding: "Show Previous Building",
+   ShortcutShowNextBuilding: "Show Next Building",
+   ShowPrevBuilding: "Previous Building",
+   ShowNextBuilding: "Next Building",
    HappinessUncapped: "Happiness (Uncapped)",
    ExtraGreatPeople: "%{count} Extra Great People",
    ScrollWheelAdjustLevelTooltip:

--- a/shared/logic/Shortcut.ts
+++ b/shared/logic/Shortcut.ts
@@ -32,6 +32,8 @@ export const ShortcutActions = {
       scope: "BuildingPage",
       name: () => t(L.ShortcutBuildingPageToggleBuildingSetAllSimilar),
    },
+   ShowPrevBuilding: { scope: "BuildingPage", name: () => t(L.ShortcutShowPrevBuilding) },
+    ShowNextBuilding: { scope: "BuildingPage", name: () => t(L.ShortcutShowNextBuilding) },
    UpgradePageIncreaseLevel: { scope: "UpgradePage", name: () => t(L.ShortcutUpgradePageIncreaseLevel) },
    UpgradePageDecreaseLevel: { scope: "UpgradePage", name: () => t(L.ShortcutUpgradePageDecreaseLevel) },
    TechPageGoBackToCity: { scope: "TechPage", name: () => t(L.ShortcutTechPageGoBackToCity) },

--- a/src/scripts/ui/BuildingConstructionProgressComponent.tsx
+++ b/src/scripts/ui/BuildingConstructionProgressComponent.tsx
@@ -17,6 +17,8 @@ import { ProgressBarComponent } from "./ProgressBarComponent";
 import { RenderHTML } from "./RenderHTMLComponent";
 import { TextWithHelp } from "./TextWithHelpComponent";
 import { WarningComponent } from "./WarningComponent";
+import {useShortcut} from "../utilities/Hook";
+import {navigateToSameTypeBuilding} from "../utilities/Building";
 
 export function BuildingConstructionProgressComponent({
    gameState,
@@ -30,36 +32,51 @@ export function BuildingConstructionProgressComponent({
    const { cost, percent, secondsLeft } = getBuildingPercentage(xy, gameState);
    const enabledResourceCount = sizeOf(cost) - building.disabledInput.size;
    const builderCapacityPerResource = enabledResourceCount > 0 ? total / enabledResourceCount : 0;
+
+   const prevBuilding = () => navigateToSameTypeBuilding(gameState, building, xy, 'prev');
+   const nextBuilding = () => navigateToSameTypeBuilding(gameState, building, xy, 'next');
+   useShortcut("ShowPrevBuilding", () => prevBuilding(), [gameState, building, xy]);
+   useShortcut("ShowNextBuilding", () => nextBuilding(), [gameState, building, xy]);
+
    return (
-      <fieldset>
-         <div className="row">
-            <div className="f1">{t(L.ConstructionProgress)}</div>
-            <div>{formatPercent(percent, 0)}</div>
-         </div>
-         <div className="sep5"></div>
-         <div className="row">
-            <div className="f1">{t(L.EstimatedTimeLeft)}</div>
-            <div>{formatHMS(secondsLeft * 1000)}</div>
-         </div>
-         <div className="sep5"></div>
-         <ProgressBarComponent progress={percent} />
-         <div className="sep10"></div>
-         <div className="table-view">
-            <table>
-               <tbody>
-                  <tr>
-                     <th style={{ width: 0 }}></th>
-                     <th>Resource</th>
-                     <th className="text-right">
-                        <TextWithHelp content={t(L.TransportAllocatedCapacityTooltip)}>Capacity</TextWithHelp>
-                     </th>
-                     <th className="text-right">Delivered</th>
-                     <th className="text-right">Total</th>
-                  </tr>
-                  {jsxMapOf(cost, (res, value) => {
-                     return (
-                        <tr key={res}>
-                           <td
+       <fieldset>
+          <div className="row">
+             <button className="f1" onClick={prevBuilding}>
+                {t(L.ShowPrevBuilding)}
+             </button>
+             <button className="f1" onClick={nextBuilding}>
+                {t(L.ShowNextBuilding)}
+             </button>
+          </div>
+          <div className="separator"></div>
+          <div className="row">
+             <div className="f1">{t(L.ConstructionProgress)}</div>
+             <div>{formatPercent(percent, 0)}</div>
+          </div>
+          <div className="sep5"></div>
+          <div className="row">
+             <div className="f1">{t(L.EstimatedTimeLeft)}</div>
+             <div>{formatHMS(secondsLeft * 1000)}</div>
+          </div>
+          <div className="sep5"></div>
+          <ProgressBarComponent progress={percent}/>
+          <div className="sep10"></div>
+          <div className="table-view">
+             <table>
+                <tbody>
+                <tr>
+                   <th style={{width: 0}}></th>
+                   <th>Resource</th>
+                   <th className="text-right">
+                      <TextWithHelp content={t(L.TransportAllocatedCapacityTooltip)}>Capacity</TextWithHelp>
+                   </th>
+                   <th className="text-right">Delivered</th>
+                   <th className="text-right">Total</th>
+                </tr>
+                {jsxMapOf(cost, (res, value) => {
+                   return (
+                       <tr key={res}>
+                          <td
                               className="pointer"
                               onClick={() => {
                                  if (building.disabledInput.has(res)) {
@@ -69,91 +86,91 @@ export function BuildingConstructionProgressComponent({
                                  }
                                  notifyGameStateUpdate();
                               }}
-                           >
-                              <Tippy content={t(L.TransportManualControlTooltip)}>
-                                 {building.disabledInput.has(res) ?? false ? (
+                          >
+                             <Tippy content={t(L.TransportManualControlTooltip)}>
+                                {building.disabledInput.has(res) ?? false ? (
                                     <div className="m-icon text-red">toggle_off</div>
-                                 ) : (
+                                ) : (
                                     <div className="m-icon text-green">toggle_on</div>
-                                 )}
-                              </Tippy>
-                           </td>
-                           <td>{Config.Resource[res].name()}</td>
-                           <td className="text-right">
-                              {building.disabledInput.has(res) ? (
+                                )}
+                             </Tippy>
+                          </td>
+                          <td>{Config.Resource[res].name()}</td>
+                          <td className="text-right">
+                             {building.disabledInput.has(res) ? (
                                  0
-                              ) : (
-                                 <FormatNumber value={builderCapacityPerResource} />
-                              )}
-                           </td>
-                           <td className="text-right">
-                              <FormatNumber value={building.resources[res] ?? 0} />
-                           </td>
-                           <td className="text-right">
-                              <FormatNumber value={value} />
-                           </td>
-                        </tr>
-                     );
-                  })}
-               </tbody>
-            </table>
-         </div>
+                             ) : (
+                                 <FormatNumber value={builderCapacityPerResource}/>
+                             )}
+                          </td>
+                          <td className="text-right">
+                             <FormatNumber value={building.resources[res] ?? 0}/>
+                          </td>
+                          <td className="text-right">
+                             <FormatNumber value={value}/>
+                          </td>
+                       </tr>
+                   );
+                })}
+                </tbody>
+             </table>
+          </div>
 
-         <div className="separator"></div>
-         {isWorldWonder(building.type) ? (
-            <>
-               <WarningComponent icon="info" className="text-small">
-                  <RenderHTML html={t(L.WonderBuilderCapacityDescHTML)} />
-               </WarningComponent>
-               <div className="sep10"></div>
-            </>
-         ) : null}
-         <ul className="tree-view">
-            <details>
-               <summary className="row">
-                  <div className="f1">{t(L.ConstructionBuilderCapacity)}</div>
-                  <div className="text-strong">
-                     <FormatNumber value={total} />
-                  </div>
-               </summary>
-               <ul>
-                  <li className="row">
-                     <div className="f1">{t(L.ConstructionBuilderBaseCapacity)}</div>
-                     <div className="text-strong">
-                        <FormatNumber value={base} />
-                     </div>
-                  </li>
-                  <li className="row">
-                     <div className="f1">{t(L.ConstructionBuilderMultiplier)}</div>
-                     <div className="text-strong">
-                        x
-                        <FormatNumber value={multiplier} />
-                     </div>
-                  </li>
-                  <ul>
-                     {Tick.current.globalMultipliers.builderCapacity.map((value) => {
-                        return (
-                           <li key={value.source} className="text-small row">
-                              <div className="f1">{value.source}</div>
-                              <div>{value.value}</div>
-                           </li>
-                        );
-                     })}
-                     {getMultipliersFor(xy, gameState).map((value) => {
-                        if (!value.worker) {
-                           return null;
-                        }
-                        return (
-                           <li key={value.source} className="text-small row">
-                              <div className="f1">{value.source}</div>
-                              <div>{value.worker}</div>
-                           </li>
-                        );
-                     })}
-                  </ul>
-               </ul>
-            </details>
-         </ul>
-      </fieldset>
+          <div className="separator"></div>
+          {isWorldWonder(building.type) ? (
+              <>
+                 <WarningComponent icon="info" className="text-small">
+                    <RenderHTML html={t(L.WonderBuilderCapacityDescHTML)}/>
+                 </WarningComponent>
+                 <div className="sep10"></div>
+              </>
+          ) : null}
+          <ul className="tree-view">
+             <details>
+                <summary className="row">
+                   <div className="f1">{t(L.ConstructionBuilderCapacity)}</div>
+                   <div className="text-strong">
+                      <FormatNumber value={total}/>
+                   </div>
+                </summary>
+                <ul>
+                   <li className="row">
+                      <div className="f1">{t(L.ConstructionBuilderBaseCapacity)}</div>
+                      <div className="text-strong">
+                         <FormatNumber value={base}/>
+                      </div>
+                   </li>
+                   <li className="row">
+                      <div className="f1">{t(L.ConstructionBuilderMultiplier)}</div>
+                      <div className="text-strong">
+                         x
+                         <FormatNumber value={multiplier}/>
+                      </div>
+                   </li>
+                   <ul>
+                      {Tick.current.globalMultipliers.builderCapacity.map((value) => {
+                         return (
+                             <li key={value.source} className="text-small row">
+                                <div className="f1">{value.source}</div>
+                                <div>{value.value}</div>
+                             </li>
+                         );
+                      })}
+                      {getMultipliersFor(xy, gameState).map((value) => {
+                         if (!value.worker) {
+                            return null;
+                         }
+                         return (
+                             <li key={value.source} className="text-small row">
+                                <div className="f1">{value.source}</div>
+                                <div>{value.worker}</div>
+                             </li>
+                         );
+                      })}
+                   </ul>
+                </ul>
+             </details>
+          </ul>
+       </fieldset>
    );
 }

--- a/src/scripts/ui/BuildingUpgradeComponent.tsx
+++ b/src/scripts/ui/BuildingUpgradeComponent.tsx
@@ -1,22 +1,16 @@
 import Tippy from "@tippyjs/react";
-import { getBuildingUpgradeLevels, getTotalBuildingCost } from "../../../shared/logic/BuildingLogic";
-import { Config } from "../../../shared/logic/Config";
-import { getGameOptions, notifyGameStateUpdate } from "../../../shared/logic/GameStateLogic";
-import { getUpgradePriority, setUpgradePriority } from "../../../shared/logic/Tile";
-import {
-   formatNumber,
-   isEmpty,
-   mapOf,
-   numberToRoman,
-   tileToPoint,
-   type Tile,
-} from "../../../shared/utilities/Helper";
-import { L, t } from "../../../shared/utilities/i18n";
-import { WorldScene } from "../scenes/WorldScene";
-import { jsxMapOf } from "../utilities/Helper";
-import { useShortcut } from "../utilities/Hook";
-import { Singleton } from "../utilities/Singleton";
-import type { IBuildingComponentProps } from "./BuildingPage";
+import {getBuildingUpgradeLevels, getTotalBuildingCost} from "../../../shared/logic/BuildingLogic";
+import {Config} from "../../../shared/logic/Config";
+import {getGameOptions, notifyGameStateUpdate} from "../../../shared/logic/GameStateLogic";
+import {getUpgradePriority, setUpgradePriority} from "../../../shared/logic/Tile";
+import {formatNumber, isEmpty, mapOf, numberToRoman, type Tile, tileToPoint,} from "../../../shared/utilities/Helper";
+import {L, t} from "../../../shared/utilities/i18n";
+import {WorldScene} from "../scenes/WorldScene";
+import {jsxMapOf} from "../utilities/Helper";
+import {useShortcut} from "../utilities/Hook";
+import {Singleton} from "../utilities/Singleton";
+import type {IBuildingComponentProps} from "./BuildingPage";
+import {navigateToSameTypeBuilding} from "../utilities/Building";
 
 export function BuildingUpgradeComponent({ gameState, xy }: IBuildingComponentProps): React.ReactNode {
    const tile = gameState.tiles.get(xy);
@@ -38,9 +32,15 @@ export function BuildingUpgradeComponent({ gameState, xy }: IBuildingComponentPr
       );
       notifyGameStateUpdate();
    };
+
+   const prevBuilding = () => navigateToSameTypeBuilding(gameState, building, xy, 'prev');
+   const nextBuilding = () => navigateToSameTypeBuilding(gameState, building, xy, 'next');
+
    useShortcut("BuildingPageUpgradeX1", () => upgrade(1), [xy]);
    useShortcut("BuildingPageUpgradeX5", () => upgrade(5), [xy]);
    useShortcut("BuildingPageUpgradeToNext10", () => upgrade(levels[levels.length - 1]), [xy]);
+   useShortcut("ShowPrevBuilding", () => prevBuilding(), [gameState, building, xy]);
+   useShortcut("ShowNextBuilding", () => nextBuilding(), [gameState, building, xy]);
 
    return (
       <>
@@ -56,6 +56,15 @@ export function BuildingUpgradeComponent({ gameState, xy }: IBuildingComponentPr
                   </div>
                   <div className="text-small text-desc">{t(L.BuildingTier)}</div>
                </div>
+            </div>
+            <div className="separator"></div>
+            <div className="row">
+               <button className="f1" onClick={prevBuilding}>
+                  {t(L.ShowPrevBuilding)}
+               </button>
+               <button className="f1" onClick={nextBuilding}>
+                  {t(L.ShowNextBuilding)}
+               </button>
             </div>
             <div className="separator"></div>
             <div className="row">

--- a/src/scripts/utilities/Building.ts
+++ b/src/scripts/utilities/Building.ts
@@ -1,0 +1,19 @@
+import type {GameState} from "../../../shared/logic/GameState";
+import type {IBuildingData} from "../../../shared/logic/Tile";
+import type {Tile} from "../../../shared/utilities/Helper";
+import {Singleton} from "./Singleton";
+import {LookAtMode, WorldScene} from "../scenes/WorldScene";
+
+export function navigateToSameTypeBuilding(gameState: GameState, building: IBuildingData | null, xy: Tile, direction: 'prev' | 'next') {
+    if(!building) return;
+    const sameBuilding = Array.from(gameState.tiles.entries())
+        .filter(([coords, tile]) => tile.building && tile.building.type === building.type && tile.explored)
+        .sort(([coords1], [coords2]) => direction === 'prev' ? coords2 - coords1 : coords1 - coords2);
+
+    const buildingIndex = sameBuilding.findIndex(([coords]) => direction === 'prev' ? coords < xy : coords > xy);
+
+    if (buildingIndex !== -1 || sameBuilding.length > 0) {
+        const index = buildingIndex === -1 ? 0 : buildingIndex;
+        Singleton().sceneManager.getCurrent(WorldScene)?.lookAtTile(sameBuilding[index][0], LookAtMode.Select);
+    }
+}


### PR DESCRIPTION
Introduced shortcuts and buttons for navigating between buildings of the same type. This feature is present in both the upgrade and construction progress components in the UI. This new functionality enhances user experience by allowing users to navigate between similar structures easily and efficiently.