### PR TITLE
add active trades section to bazaar UI

### DIFF
--- a/shared/languages/en.ts
+++ b/shared/languages/en.ts
@@ -1027,4 +1027,5 @@ export const EN = {
    SidePanelWidthDescHTML:
       "Change the width of the side panel. <b>Require restarting your game to take effect</b>",
    ShowUnbuiltOnly: "Only show buildings that haven't been built yet",
+   ActiveMarketTrades: "Active Market Trades",
 };

--- a/src/scripts/ui/GrandBazaarBuildingBody.tsx
+++ b/src/scripts/ui/GrandBazaarBuildingBody.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import type { Resource } from "../../../shared/definitions/ResourceDefinitions";
 import { getMarketBuyAmount, getMarketSellAmount } from "../../../shared/logic/BuildingLogic";
 import { Config } from "../../../shared/logic/Config";
@@ -262,6 +262,102 @@ export function GrandBazaarBuildingBody({ gameState, xy }: IBuildingComponentPro
                );
             }}
          />
+         <div className="sep10"></div>
+         <fieldset>
+            <legend>{t(L.ActiveMarketTrades)}</legend>
+            <TableView             
+            classNames="sticky-header f1"
+            header={[
+               { name: t(L.MarketYouPay), sortable: true },
+               { name: t(L.MarketYouGet), sortable: true },
+               { name: "", sortable: true },
+               { name: "", sortable: false },
+               { name: "", sortable: false },
+            ]}
+            data={allMarketTrades.filter(item => {
+               const building = gameState.tiles.get(item.xy)?.building as IMarketBuildingData;
+               return building.sellResources[item.sellResource]
+            })} 
+            renderRow={function (item): ReactNode {
+               const building = gameState.tiles.get(item.xy)?.building as IMarketBuildingData;
+               const sellResource = Config.Resource[item.sellResource];
+               const buyResource = Config.Resource[item.buyResource];
+               const tradeValue = calculateTradeValue(item);
+               return (
+                  <tr key={`Res:${item.sellResource}Tile:${item.xy}`}>
+                     <td>
+                        <div>{sellResource.name()}</div>
+                        <div className="text-small text-desc text-strong">
+                           <FormatNumber value={item.sellAmount} />
+                        </div>
+                     </td>
+                     <td>
+                        <div>{buyResource.name()}</div>
+                        <div className="text-small text-desc text-strong">
+                           <FormatNumber value={item.buyAmount} />
+                        </div>
+                     </td>
+                     <td
+                        className={classNames({
+                           "text-green": tradeValue > 0,
+                           "text-red": tradeValue < 0,
+                           "text-right text-small": true,
+                        })}
+                     >
+                        <TextWithHelp
+                           content={t(L.MarketValueDesc, {
+                              value: formatPercent(tradeValue, 0),
+                           })}
+                           noStyle
+                        >
+                           {mathSign(tradeValue, CURRENCY_EPSILON)}
+                           {formatPercent(Math.abs(tradeValue), 0)}
+                        </TextWithHelp>
+                     </td>
+                     <td  style={{ width: 0 }}>
+                        <div
+                        className="m-icon small text-red pointer"
+                        onClick={() => {
+                           playClick();
+                           delete building.sellResources[item.sellResource];
+                           notifyGameStateUpdate();
+                        }}>
+                           delete
+                        </div>
+                     </td>
+                     <td style={{ width: 0 }}>
+                        <div
+                           className="m-icon small pointer"
+                           onPointerDown={() => {
+                              playClick();
+                              Singleton()
+                                 .sceneManager.getCurrent(WorldScene)
+                                 ?.lookAtTile(item.xy, LookAtMode.Select);
+                           }}
+                        >
+                           open_in_new
+                        </div>
+                     </td>
+                  </tr>
+               );
+            } } 
+            compareFunc={(a, b, i) => {
+               switch (i) {
+                  case 0:
+                     return Config.Resource[a.sellResource]
+                        .name()
+                        .localeCompare(Config.Resource[b.sellResource].name());
+                  case 1:
+                     return Config.Resource[a.buyResource]
+                        .name()
+                        .localeCompare(Config.Resource[b.buyResource].name());
+                  case 2:
+                     return (calculateTradeValue(a) ?? 0) - (calculateTradeValue(b) ?? 0);
+                  default:
+                     return 0;
+               }
+            }} />
+         </fieldset>
          <div className="sep10"></div>
          <BuildingWikipediaComponent gameState={gameState} xy={xy} />
          <BuildingColorComponent gameState={gameState} xy={xy} />

--- a/src/scripts/ui/GrandBazaarBuildingBody.tsx
+++ b/src/scripts/ui/GrandBazaarBuildingBody.tsx
@@ -278,7 +278,7 @@ export function GrandBazaarBuildingBody({ gameState, xy }: IBuildingComponentPro
                const building = gameState.tiles.get(item.xy)?.building as IMarketBuildingData;
                return building.sellResources[item.sellResource]
             })} 
-            renderRow={function (item): ReactNode {
+            renderRow={(item) => {
                const building = gameState.tiles.get(item.xy)?.building as IMarketBuildingData;
                const sellResource = Config.Resource[item.sellResource];
                const buyResource = Config.Resource[item.buyResource];


### PR DESCRIPTION
I thought it'd be nice to have an overview of active trades on the bazaar, so I copy-pasted something together. 

![image](https://github.com/fishpondstudio/CivIdle/assets/6831612/25db55fb-d8f5-4343-9f97-c3ee0fe6b66b)

Kept it simple for now, looking for some feedback:

- I'm not a fan of the table nested in the fieldset, but I couldn't find a better header-like element to use. Any suggestions?
- Much of the row render code (with the exception of the trade toggle) and all of the sort code is duplicated between the filtered table. Worth pulling into a separate function/component?

On a meta note, I couldn't find any information on contributions, so I just gave it a shot. I'll happily contribute under an open source license of your choosing, and/or sign a contributor agreement to that effect if required. 