### PR TITLE
Only allow trade for unlocked resources

### DIFF
--- a/src/scripts/ui/AddTradeComponent.tsx
+++ b/src/scripts/ui/AddTradeComponent.tsx
@@ -15,6 +15,7 @@ import type { IBuildingComponentProps } from "./BuildingPage";
 import { showToast } from "./GlobalModal";
 import { FormatNumber } from "./HelperComponents";
 import { TextWithHelp } from "./TextWithHelpComponent";
+import { unlockedResources } from "../../../shared/logic/IntraTickCache";
 
 export function AddTradeComponent({ gameState, xy }: IBuildingComponentProps): React.ReactNode {
    const user = useUser();
@@ -22,9 +23,7 @@ export function AddTradeComponent({ gameState, xy }: IBuildingComponentProps): R
    const enabled =
       !isNullOrUndefined(user) &&
       trades.filter((t) => t.fromId === user.userId).length < getMaxActiveTrades(user);
-   const buyResources = Array.from(Tick.next.resourcesByTile.keys()).filter(
-      (res) => !NoPrice[res] && !NoStorage[res],
-   );
+   const buyResources = keysOf(unlockedResources(gameState)).filter((r) => !NoStorage[r] && !NoPrice[r]);
    const resourcesInStorage = gameState.tiles.get(xy)?.building?.resources ?? {};
    const sellResources = keysOf(resourcesInStorage);
    const [trade, setTrade] = useState<IClientAddTradeRequest>({

--- a/src/scripts/ui/PlayerTradeComponent.tsx
+++ b/src/scripts/ui/PlayerTradeComponent.tsx
@@ -149,9 +149,11 @@ export function PlayerTradeComponent({ gameState, xy }: IBuildingComponentProps)
             ]}
             data={trades.filter(
                (trade) =>
-                  resourceFilters.size === 0 ||
-                  resourceFilters.has(trade.buyResource) ||
-                  resourceFilters.has(trade.sellResource),
+                  resources.includes(trade.buyResource) &&
+                  resources.includes(trade.sellResource) &&
+                  (resourceFilters.size === 0 ||
+                     resourceFilters.has(trade.buyResource) ||
+                     resourceFilters.has(trade.sellResource)),
             )}
             compareFunc={(a, b, col) => {
                switch (col) {


### PR DESCRIPTION
Fixes https://github.com/fishpondstudio/CivIdle/issues/162

Now only shows trades for resources that you have unlocked.

The I want drop down for adding a trade now only shows resources that have been unlocked.