### PR TITLE
Update de.ts

### DIFF
--- a/shared/languages/de.ts
+++ b/shared/languages/de.ts
@@ -845,7 +845,7 @@ export const DE = {
    SidePanelWidth: "Breite des seitlichen Menüfensters",
    SidePanelWidthDescHTML:
       "Breitenanpassung für das seitliche Menüfensters. <b>Ein Neustart des Spiels ist erforderlich</b>",
-   SiegeRam: "Belagerungswidder",
+   SiegeRam: "Ramme",
    SiegeWorkshop: "Belagerungswerkstatt",
    Skyscrapper: "Wolkenkratzer",
    Smartphone: "Smartphone",


### PR DESCRIPTION
Just one small change: The former translation of SiegeRam renders the market window unusable: There is no sideway slidepanel there at the moment and thus it's not possible to activate/deactivate single entries on the market.