### PR TITLE
Fix for Matrioshka Brain upgrade removing science from Statistics Office

### DIFF
--- a/shared/logic/Update.ts
+++ b/shared/logic/Update.ts
@@ -377,6 +377,9 @@ export function transportAndConsumeResources(
       // when upgrade completes:
       if (building.status === "upgrading" && isWorldWonder(building.type)) {
          OnBuildingProductionComplete.emit({ xy, offline });
+         if(Config.Building[building.type].name() === "Matrioshka Brain"){
+            Tick.next.specialBuildings.set(building.type, tile as Required<ITileData>); //fixes drop from Statistics Office while upgrading
+         }
       }
 
       if (completed) {


### PR DESCRIPTION
This adds a check to the tick upgrading section to set the Special Building for Matrioshka Brain. Without this, when you upgrade Matrioshka Brain Science will not show up in your Statistics Office list.