### PR TITLE
Fix crash when deleting caravans with England

### DIFF
--- a/src/scripts/logic/OnProductionComplete.tsx
+++ b/src/scripts/logic/OnProductionComplete.tsx
@@ -1519,7 +1519,7 @@ export function onProductionComplete({ xy, offline }: { xy: Tile; offline: boole
          if ((building.resources.TradeValue ?? 0) > EAST_INDIA_COMPANY_BOOST_PER_EV) {
             safeAdd(building.resources, "TradeValue", -EAST_INDIA_COMPANY_BOOST_PER_EV);
             getBuildingsByType("Caravansary", gs)?.forEach((tile, xy) => {
-               if (tile.building.status !== "completed" || tile.building.capacity <= 0) {
+               if (!getWorkingBuilding(xy, gs)) {
                   return;
                }
                grid.getNeighbors(tileToPoint(xy)).forEach((p) => {


### PR DESCRIPTION
Crash happens when deleting caravans on England map due to tile.building being null

![image](https://github.com/user-attachments/assets/058e2023-9b30-4fe5-95f5-6a582c69a75e)
