### PR TITLE
Able to filter player names in the Caravansary trades list

### DIFF
--- a/src/scripts/ui/PlayerTradeComponent.tsx
+++ b/src/scripts/ui/PlayerTradeComponent.tsx
@@ -242,15 +242,21 @@ export function PlayerTradeComponent({ gameState, xy }: IBuildingComponentProps)
                { name: "", sortable: false },
             ]}
             sortingState={playerTradesSortingState}
-            data={trades.filter(
-               (trade) =>
+            data={trades.filter((trade) => {
+               const filterNames = playerNameFilter
+                  .toLowerCase()
+                  .split(",")
+                  .map((name) => name.trim())
+                  .filter((name) => name.length > 0);
+
+               return (
                   ((resourceWantFilters.size === 0 && resourceOfferFilters.size === 0) ||
                      resourceWantFilters.has(trade.buyResource) ||
                      resourceOfferFilters.has(trade.sellResource)) &&
-                  trade.from.toLowerCase().includes(playerNameFilter.toLowerCase()) &&
-                  (tradeAmountFilter === 0 ||
-                     (tradeAmountFilter > 0 && trade.buyAmount <= tradeAmountFilter)),
-            )}
+                  filterNames.some((name) => trade.from.toLowerCase().includes(name)) &&
+                  (tradeAmountFilter === 0 || (tradeAmountFilter > 0 && trade.buyAmount <= tradeAmountFilter))
+               );
+            })}
             compareFunc={(a, b, col, asc) => {
                if (a.fromId === user?.userId && b.fromId !== user?.userId) {
                   return -asc;

--- a/src/scripts/ui/PlayerTradeComponent.tsx
+++ b/src/scripts/ui/PlayerTradeComponent.tsx
@@ -245,7 +245,7 @@ export function PlayerTradeComponent({ gameState, xy }: IBuildingComponentProps)
             data={trades.filter((trade) => {
                const filterNames = playerNameFilter
                   .toLowerCase()
-                  .split(",")
+                  .split(" ")
                   .map((name) => name.trim())
                   .filter((name) => name.length > 0);
 


### PR DESCRIPTION
Able to filter player names in the Caravansary trades list, by using comma's.  e.g.  Fishpond,Vethon etc

Only tested locally with hardcoded data.

Requested here.
https://discord.com/channels/631551126377857044/1350172079349039195/1350191765834956973