### PR TITLE
Stop moving the map when selecting deficits from resource bar

### DIFF
--- a/src/scripts/ui/ResourcePanel.tsx
+++ b/src/scripts/ui/ResourcePanel.tsx
@@ -29,6 +29,7 @@ import {
    mathSign,
    range,
    round,
+   tileToPoint,
    type Tile,
 } from "../../../shared/utilities/Helper";
 import { L, t } from "../../../shared/utilities/i18n";
@@ -436,7 +437,7 @@ function DeficitResources(): React.ReactNode {
             onClick={() => {
                const s = Tick.current.specialBuildings.get("Statistics");
                if (s) {
-                  Singleton().sceneManager.getCurrent(WorldScene)?.lookAtTile(s.tile, LookAtMode.Select);
+                  Singleton().sceneManager.getCurrent(WorldScene)?.selectGrid(tileToPoint(s.tile));
                }
             }}
          >


### PR DESCRIPTION
Stops moving the map when you select the deficits from the top resource bar.

Requested here:
https://discord.com/channels/631551126377857044/1350172079349039195/1350192265124905082