### PR TITLE
Always show your own trades when filtering

### DIFF
--- a/src/scripts/ui/PlayerTradeComponent.tsx
+++ b/src/scripts/ui/PlayerTradeComponent.tsx
@@ -250,11 +250,13 @@ export function PlayerTradeComponent({ gameState, xy }: IBuildingComponentProps)
                   .filter((name) => name.length > 0);
 
                return (
-                  ((resourceWantFilters.size === 0 && resourceOfferFilters.size === 0) ||
+                  trade.fromId === user?.userId ||
+                  (((resourceWantFilters.size === 0 && resourceOfferFilters.size === 0) ||
                      resourceWantFilters.has(trade.buyResource) ||
                      resourceOfferFilters.has(trade.sellResource)) &&
-                  filterNames.some((name) => trade.from.toLowerCase().includes(name)) &&
-                  (tradeAmountFilter === 0 || (tradeAmountFilter > 0 && trade.buyAmount <= tradeAmountFilter))
+                     filterNames.some((name) => trade.from.toLowerCase().includes(name)) &&
+                     (tradeAmountFilter === 0 ||
+                        (tradeAmountFilter > 0 && trade.buyAmount <= tradeAmountFilter)))
                );
             })}
             compareFunc={(a, b, col, asc) => {


### PR DESCRIPTION
Always show your own trades when filters are applied.

This is untested as locally there is no `User` to compare against the trade `fromId`

Requested Here:
https://discord.com/channels/631551126377857044/1350172079349039195/1351033400747626516