### PR TITLE
fix(shared): Prevent excess input resources in Clone Factories

### DIFF
--- a/shared/logic/Update.ts
+++ b/shared/logic/Update.ts
@@ -152,7 +152,9 @@ export function completeTransport(targetBuilding: IBuildingData, resource: Mater
    safeAdd(targetBuilding.resources, resource, amount);
    if (targetBuilding.type === "CloneFactory") {
       const clone = targetBuilding as ICloneBuildingData;
-      clone.transportedAmount += amount;
+      if (clone.inputResource === resource) {
+         clone.transportedAmount += amount;
+      }
    }
 }
 


### PR DESCRIPTION
Clone Factories should only increase their `transportedAmount` if the resource arriving matches the factory's input resource.

Otherwise, you can cheese the Factory by calling for an upgrade then cancelling it, using Software and Tanks (which don't get used up) to increase the "clonable" amount of the input resource, allowing the Factory to run for a long time on its own output.

Fixes #597.