### PR TITLE
Update OnProductionComplete.tsx

### DIFF
--- a/src/scripts/logic/OnProductionComplete.tsx
+++ b/src/scripts/logic/OnProductionComplete.tsx
@@ -805,7 +805,7 @@ export function onProductionComplete({ xy, offline }: { xy: Tile; offline: boole
                addMultiplier(b, { output: 1 }, buildingName);
             }
          });
-         for (const point of grid.getRange(tileToPoint(xy), 1)) {
+         for (const point of grid.getRange(tileToPoint(xy), 2)) {
             Tick.next.powerGrid.add(pointToTile(point));
          }
          break;
@@ -1432,7 +1432,7 @@ export function onProductionComplete({ xy, offline }: { xy: Tile; offline: boole
          break;
       }
       case "OsakaCastle": {
-         for (const point of grid.getRange(tileToPoint(xy), 1)) {
+         for (const point of grid.getRange(tileToPoint(xy), 2)) {
             Tick.next.powerGrid.add(pointToTile(point));
          }
          break;


### PR DESCRIPTION
Osaka & GoldenGate had wrong effect: PowerPlant
Correct: PowerGrid -- compare ItaipuDam and AkademikLomonosov

PowerPlant = adds another +1 range around the tile, making range 2 effectively range 3.